### PR TITLE
improve output and fix service restart behavior

### DIFF
--- a/internal/exporter/host/host.go
+++ b/internal/exporter/host/host.go
@@ -89,7 +89,6 @@ func (e *ExporterHostSyncer) SyncExporterHosts() error {
 			if err != nil {
 				return fmt.Errorf("error rendering template config for %s : %w", errName, err)
 			}
-			fmt.Printf("   	[%s] Rendered config correctly\n", exporterInstance.Name)
 
 			if e.debugConfigs {
 				fmt.Printf("--- 📄 Config Template %s\n", strings.Repeat("─", 40))

--- a/internal/instance/client_sync.go
+++ b/internal/instance/client_sync.go
@@ -95,7 +95,7 @@ func (i *Instance) updateClient(ctx context.Context, oldClientObj, clientObj *v1
 	// Prepare metadata (annotations, namespace, etc.)
 	// For updates, we want to preserve existing annotations and merge new ones
 	i.prepareMetadata(&updatedClient.ObjectMeta, clientObj.Annotations)
-	changed := i.checkAndPrintDiff(oldClientObj, updatedClient, "client", updatedClient.Name)
+	changed := i.checkAndPrintDiff(oldClientObj, updatedClient, "client", updatedClient.Name, i.dryRun)
 	if i.dryRun || !changed {
 		return nil
 	}

--- a/internal/instance/exporter_sync.go
+++ b/internal/instance/exporter_sync.go
@@ -66,7 +66,7 @@ func (i *Instance) updateExporter(ctx context.Context, oldExporter, exporter *v1
 
 		// Only print diff on first attempt to avoid spam
 		if attempt == 0 {
-			changed := i.checkAndPrintDiff(oldExporter, updatedExporter, "exporter", updatedExporter.Name)
+			changed := i.checkAndPrintDiff(oldExporter, updatedExporter, "exporter", updatedExporter.Name, i.dryRun)
 			if !changed {
 				return nil
 			}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -159,7 +159,7 @@ func validateInstance(instance *v1alphaConfig.JumpstarterInstance) error {
 }
 
 // checkAndPrintDiff prints a diff between two objects, ignoring Kubernetes metadata fields
-func (i *Instance) checkAndPrintDiff(oldObj, newObj interface{}, objType, objName string) bool {
+func (i *Instance) checkAndPrintDiff(oldObj, newObj interface{}, objType, objName string, dry bool) bool {
 	// Options to ignore Kubernetes metadata fields that change frequently
 	ignoreOpts := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Generation", "CreationTimestamp", "ResourceVersion", "UID", "ManagedFields"),
@@ -168,11 +168,13 @@ func (i *Instance) checkAndPrintDiff(oldObj, newObj interface{}, objType, objNam
 	}
 
 	diff := cmp.Diff(oldObj, newObj, ignoreOpts...)
-	if diff != "" {
-		fmt.Printf("📝 [%s] dry run: Would update %s %s, diff: %s\n", i.config.Name, objType, objName, diff)
-		return true
+	if dry {
+		if diff != "" {
+			fmt.Printf("📝 [%s] dry run: Would update %s %s, diff: %s\n", i.config.Name, objType, objName, diff)
+		} else {
+			fmt.Printf("✅ [%s] dry run: No changes needed for %s %s\n", i.config.Name, objType, objName)
+		}
 	}
 
-	fmt.Printf("✅ [%s] dry run: No changes needed for %s %s\n", i.config.Name, objType, objName)
-	return false
+	return diff != ""
 }


### PR DESCRIPTION
make dry run mode more verbose and production apply less verbose when there are no changes. fix systemctl enable .service, needed only for services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dry-run feedback with clearer messages indicating whether updates would occur or if no changes are needed.
  * Enhanced dry-run output for service management, including success messages after service restarts.

* **Bug Fixes**
  * More accurate handling of system service enablement and restarts based on specific file changes.

* **Tests**
  * Added and updated tests to verify dry-run output behavior and ensure correct change detection.

* **Style**
  * Removed unnecessary debug print statements for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->