### PR TITLE
fix podman auto-update check

### DIFF
--- a/internal/exporter/ssh/ssh.go
+++ b/internal/exporter/ssh/ssh.go
@@ -238,7 +238,7 @@ func (m *SSHHostManager) Apply(exporterConfig *v1alpha1.ExporterConfigTemplate, 
 				if dryRun {
 					fmt.Printf("            ✅ Exporter container image is up to date\n")
 				}
-			case "true":
+			case "pending":
 				if dryRun {
 					fmt.Printf("            📄 Would update container %s\n", svcName)
 				} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-update status now reports a “pending” state for clearer operator feedback.
  * Dry-run output accurately indicates a pending update rather than reporting the container as up to date.
  * Runtime behavior unchanged: when an update is pending, the exporter service is restarted.
  * Improves clarity around update readiness and expected actions during maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->