### PR TITLE
add support for skipping exporter update

### DIFF
--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -1,5 +1,41 @@
 package v1alpha1
 
+const (
+	DeadAnnotation       = "jumpstarter.dev/dead"
+	LegacyDeadAnnotation = "dead"
+	UnmanagedAnnotation  = "jumpstarter.dev/unmanaged"
+)
+
 func (e *ExporterInstance) HasConfigTemplate() bool {
 	return e.Spec.ConfigTemplateRef.Name != ""
+}
+
+func (e *ExporterInstance) IsUnmanaged() (bool, string) {
+	if e == nil || e.Annotations == nil {
+		return false, ""
+	}
+
+	value, exists := e.Annotations[UnmanagedAnnotation]
+	if !exists {
+		return false, ""
+	}
+
+	return true, value
+}
+
+func (e *ExporterInstance) IsDead() (bool, string) {
+	if e == nil || e.Annotations == nil {
+		return false, ""
+	}
+
+	if value, exists := e.Annotations[DeadAnnotation]; exists {
+		return true, value
+	}
+
+	// Backward compatibility for existing configs still using the legacy key.
+	if value, exists := e.Annotations[LegacyDeadAnnotation]; exists {
+		return true, value
+	}
+
+	return false, ""
 }

--- a/api/v1alpha1/helpers_test.go
+++ b/api/v1alpha1/helpers_test.go
@@ -114,3 +114,148 @@ func TestExporterInstance_HasConfigTemplate_EdgeCases(t *testing.T) {
 		assert.True(t, instance.HasConfigTemplate(), "HasConfigTemplate() should return true for template name with special characters")
 	})
 }
+
+func TestExporterInstance_IsUnmanaged(t *testing.T) {
+	tests := []struct {
+		name          string
+		instance      *ExporterInstance
+		expectedState bool
+		expectedValue string
+	}{
+		{
+			name:          "nil instance",
+			instance:      nil,
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "no annotations",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-exporter",
+				},
+			},
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "managed exporter with other annotation",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-exporter",
+					Annotations: map[string]string{
+						"example": "value",
+					},
+				},
+			},
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "unmanaged exporter with empty discovery date",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-exporter",
+					Annotations: map[string]string{
+						UnmanagedAnnotation: "",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "",
+		},
+		{
+			name: "unmanaged exporter with discovery date",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-exporter",
+					Annotations: map[string]string{
+						UnmanagedAnnotation: "2026-02-01",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "2026-02-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isUnmanaged, value := tt.instance.IsUnmanaged()
+			assert.Equal(t, tt.expectedState, isUnmanaged)
+			assert.Equal(t, tt.expectedValue, value)
+		})
+	}
+}
+
+func TestExporterInstance_IsDead(t *testing.T) {
+	tests := []struct {
+		name          string
+		instance      *ExporterInstance
+		expectedState bool
+		expectedValue string
+	}{
+		{
+			name:          "nil instance",
+			instance:      nil,
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "no annotations",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "exporter"},
+			},
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "dead via current annotation key",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exporter",
+					Annotations: map[string]string{
+						DeadAnnotation: "maintenance",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "maintenance",
+		},
+		{
+			name: "dead via legacy annotation key",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exporter",
+					Annotations: map[string]string{
+						LegacyDeadAnnotation: "legacy-maintenance",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "legacy-maintenance",
+		},
+		{
+			name: "dead annotation takes precedence over legacy annotation",
+			instance: &ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "exporter",
+					Annotations: map[string]string{
+						DeadAnnotation:       "current-maintenance",
+						LegacyDeadAnnotation: "legacy-maintenance",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "current-maintenance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isDead, value := tt.instance.IsDead()
+			assert.Equal(t, tt.expectedState, isDead)
+			assert.Equal(t, tt.expectedValue, value)
+		})
+	}
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -19,7 +19,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/exporter/template"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/instance"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/templating"
+	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/unmanaged"
 )
 
 var applyCmd = &cobra.Command{
@@ -61,6 +64,7 @@ var applyCmd = &cobra.Command{
 		}
 
 		config_lint.Validate(cfg)
+		unmanagedSummary := unmanaged.ProcessUnmanagedExporters(cfg, dryRun, time.Now)
 
 		tapplier, err := templating.NewTemplateApplier(cfg, nil)
 		if err != nil {
@@ -112,7 +116,12 @@ var applyCmd = &cobra.Command{
 				return fmt.Errorf("error syncing clients for %s: %w", inst.Name, err)
 			}
 
-			instanceServiceParametersMap, err := instanceClient.SyncExporters(context.Background(), cfg, exporterFilter)
+			instanceServiceParametersMap, err := instanceClient.SyncExporters(
+				context.Background(),
+				cfg,
+				exporterFilter,
+				unmanagedSummary.Exporters,
+			)
 			if err != nil {
 				return fmt.Errorf("error syncing exporters for %s: %w", inst.Name, err)
 			} else {
@@ -129,6 +138,23 @@ var applyCmd = &cobra.Command{
 		err = exporterHostSyncer.SyncExporterHosts()
 		if err != nil {
 			return fmt.Errorf("error syncing exporter hosts: %w", err)
+		}
+
+		if unmanagedSummary.Count() > 0 {
+			if unmanagedSummary.OldestDays > 0 {
+				_, _ = fmt.Fprintf(
+					os.Stderr,
+					"\n⚠️  Warning: %d exporter(s) are unmanaged (oldest: %d day(s)). "+
+						"They were skipped for sync.\n",
+					unmanagedSummary.Count(), unmanagedSummary.OldestDays,
+				)
+			} else {
+				_, _ = fmt.Fprintf(
+					os.Stderr,
+					"\n⚠️  Warning: %d exporter(s) are unmanaged. They were skipped for sync.\n",
+					unmanagedSummary.Count(),
+				)
+			}
 		}
 
 		return nil

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -537,8 +537,8 @@ func formatLocation(exporterInstance *v1alpha1.ExporterInstance) string {
 func formatNotes(exporterInstance *v1alpha1.ExporterInstance) string {
 	var noteParts []string
 
-	// Check for "dead" annotation and add to notes FIRST
-	if deadAnnotation, exists := exporterInstance.Annotations["dead"]; exists {
+	// Check for dead annotation and add to notes FIRST
+	if isDead, deadAnnotation := exporterInstance.IsDead(); isDead {
 		deadNote := "**DEAD**"
 		if deadAnnotation != "" {
 			deadNote += ": " + deadAnnotation

--- a/internal/config/annotation_writer.go
+++ b/internal/config/annotation_writer.go
@@ -1,0 +1,231 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UpdateAnnotationInSourceFile updates an annotation value in a YAML source file.
+// It uses yaml.Node for round-trip parsing to preserve comments and formatting.
+// For multi-document YAML files, it matches on metadata.name to find the correct document.
+func UpdateAnnotationInSourceFile(filePath, objectName, annotationKey, newValue string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error reading file %s: %w", filePath, err)
+	}
+
+	// Parse all documents using yaml.Node
+	var documents []*yaml.Node
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	preserveLeadingDocStart := hasLeadingDocStart(data)
+
+	for {
+		var doc yaml.Node
+		err := decoder.Decode(&doc)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("error decoding YAML from %s: %w", filePath, err)
+		}
+		documents = append(documents, &doc)
+	}
+
+	if len(documents) == 0 {
+		return fmt.Errorf("no YAML documents found in %s", filePath)
+	}
+
+	found := false
+	for _, doc := range documents {
+		// Each decoded yaml.Node is a Document node wrapping the actual content
+		if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+			continue
+		}
+
+		root := doc.Content[0]
+		if root.Kind != yaml.MappingNode {
+			continue
+		}
+
+		// Check if this document's metadata.name matches
+		name := getMetadataName(root)
+		if name != objectName {
+			continue
+		}
+
+		// Find or create the annotations key under metadata
+		if err := setAnnotationValue(root, annotationKey, newValue); err != nil {
+			return fmt.Errorf("error setting annotation in %s: %w", filePath, err)
+		}
+		found = true
+		break
+	}
+
+	if !found {
+		return fmt.Errorf("object %s not found in %s", objectName, filePath)
+	}
+
+	// Write back
+	out, err := marshalDocuments(documents, preserveLeadingDocStart)
+	if err != nil {
+		return fmt.Errorf("error marshaling YAML for %s: %w", filePath, err)
+	}
+
+	// Preserve original file permissions
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("error stating file %s: %w", filePath, err)
+	}
+
+	return writeFileAtomically(filePath, out, info.Mode())
+}
+
+// getMetadataName extracts metadata.name from a mapping node
+func getMetadataName(root *yaml.Node) string {
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		keyNode := root.Content[i]
+		valNode := root.Content[i+1]
+
+		if keyNode.Value == "metadata" && valNode.Kind == yaml.MappingNode {
+			for j := 0; j < len(valNode.Content)-1; j += 2 {
+				if valNode.Content[j].Value == "name" {
+					return valNode.Content[j+1].Value
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// setAnnotationValue sets an annotation key/value in the metadata mapping.
+// Creates the annotations mapping if it doesn't exist.
+func setAnnotationValue(root *yaml.Node, annotationKey, newValue string) error {
+	// Find the metadata mapping
+	var metadataNode *yaml.Node
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		if root.Content[i].Value == "metadata" && root.Content[i+1].Kind == yaml.MappingNode {
+			metadataNode = root.Content[i+1]
+			break
+		}
+	}
+
+	if metadataNode == nil {
+		return fmt.Errorf("metadata not found")
+	}
+
+	// Find the annotations mapping
+	var annotationsNode *yaml.Node
+	for i := 0; i < len(metadataNode.Content)-1; i += 2 {
+		if metadataNode.Content[i].Value == "annotations" && metadataNode.Content[i+1].Kind == yaml.MappingNode {
+			annotationsNode = metadataNode.Content[i+1]
+			break
+		}
+	}
+
+	if annotationsNode == nil {
+		// Create annotations mapping
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "annotations", Tag: "!!str"}
+		valNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		metadataNode.Content = append(metadataNode.Content, keyNode, valNode)
+		annotationsNode = valNode
+	}
+
+	// Find or create the annotation key
+	for i := 0; i < len(annotationsNode.Content)-1; i += 2 {
+		if annotationsNode.Content[i].Value == annotationKey {
+			annotationsNode.Content[i+1].Value = newValue
+			annotationsNode.Content[i+1].Tag = "!!str"
+			annotationsNode.Content[i+1].Style = yaml.DoubleQuotedStyle
+			return nil
+		}
+	}
+
+	// Key not found, add it
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: annotationKey, Tag: "!!str"}
+	valNode := &yaml.Node{Kind: yaml.ScalarNode, Value: newValue, Tag: "!!str", Style: yaml.DoubleQuotedStyle}
+	annotationsNode.Content = append(annotationsNode.Content, keyNode, valNode)
+
+	return nil
+}
+
+func hasLeadingDocStart(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return strings.HasPrefix(trimmed, "---")
+	}
+	return false
+}
+
+// marshalDocuments serializes multiple yaml.Node documents back to bytes,
+// separating them with ---
+func marshalDocuments(documents []*yaml.Node, preserveLeadingDocStart bool) ([]byte, error) {
+	var result []byte
+
+	for i, doc := range documents {
+		if i > 0 || preserveLeadingDocStart {
+			result = append(result, []byte("---\n")...)
+		}
+
+		out, err := yaml.Marshal(doc)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, out...)
+	}
+
+	return result, nil
+}
+
+func writeFileAtomically(filePath string, content []byte, mode os.FileMode) error {
+	dir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+
+	tmpFile, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("error creating temp file for %s: %w", filePath, err)
+	}
+
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("error setting mode on temp file for %s: %w", filePath, err)
+	}
+
+	if _, err := tmpFile.Write(content); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("error writing temp file for %s: %w", filePath, err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("error syncing temp file for %s: %w", filePath, err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing temp file for %s: %w", filePath, err)
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		return fmt.Errorf("error replacing %s with temp file: %w", filePath, err)
+	}
+
+	cleanup = false
+	return nil
+}

--- a/internal/config/annotation_writer_test.go
+++ b/internal/config/annotation_writer_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type exporterInstanceDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name        string            `yaml:"name"`
+		Annotations map[string]string `yaml:"annotations"`
+	} `yaml:"metadata"`
+}
+
+func decodeExporterInstanceDocs(t *testing.T, content []byte) []exporterInstanceDoc {
+	t.Helper()
+
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	docs := make([]exporterInstanceDoc, 0)
+
+	for {
+		var doc exporterInstanceDoc
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if doc.Kind == "" && doc.Metadata.Name == "" {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+
+	return docs
+}
+
+func getExporterInstanceDocByName(docs []exporterInstanceDoc, name string) (exporterInstanceDoc, bool) {
+	for _, doc := range docs {
+		if doc.Metadata.Name == name {
+			return doc, true
+		}
+	}
+
+	return exporterInstanceDoc{}, false
+}
+
+func TestUpdateAnnotationInSourceFile_SingleDocument(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: my-exporter
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporter.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "my-exporter", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result), `jumpstarter.dev/unmanaged: "2026-02-09"`)
+	// Verify other content is preserved
+	assert.Contains(t, string(result), "kind: ExporterInstance")
+	assert.Contains(t, string(result), "name: my-exporter")
+	assert.Contains(t, string(result), "type: test")
+}
+
+func TestUpdateAnnotationInSourceFile_MultiDocument(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-1
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test1
+---
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-2
+spec:
+  type: test2
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporters.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "exporter-1", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	docs := decodeExporterInstanceDocs(t, result)
+	require.Len(t, docs, 2)
+
+	exporter1, found := getExporterInstanceDocByName(docs, "exporter-1")
+	require.True(t, found)
+	assert.Equal(t, "2026-02-09", exporter1.Metadata.Annotations["jumpstarter.dev/unmanaged"])
+
+	// Verify the second document has no annotations.
+	exporter2, found := getExporterInstanceDocByName(docs, "exporter-2")
+	require.True(t, found)
+	assert.Empty(t, exporter2.Metadata.Annotations)
+}
+
+func TestUpdateAnnotationInSourceFile_NoAnnotationsSection(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: my-exporter
+spec:
+  type: test
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporter.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "my-exporter", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, "annotations:")
+	assert.Contains(t, resultStr, `jumpstarter.dev/unmanaged: "2026-02-09"`)
+}
+
+func TestUpdateAnnotationInSourceFile_ObjectNotFound(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: other-exporter
+spec:
+  type: test
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporter.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "my-exporter", "jumpstarter.dev/unmanaged", "2026-02-09")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "object my-exporter not found")
+}
+
+func TestUpdateAnnotationInSourceFile_PreservesComments(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: my-exporter
+  annotations:
+    # This exporter is being debugged
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test # important type
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporter.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "my-exporter", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, `jumpstarter.dev/unmanaged: "2026-02-09"`)
+	assert.Contains(t, resultStr, "This exporter is being debugged")
+}
+
+func TestUpdateAnnotationInSourceFile_UpdatesCorrectDocumentInMultiDoc(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-1
+spec:
+  type: test1
+---
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-2
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test2
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporters.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	// Update annotation on second document
+	err := UpdateAnnotationInSourceFile(filePath, "exporter-2", "jumpstarter.dev/unmanaged", "2026-01-15")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	docs := decodeExporterInstanceDocs(t, result)
+	require.Len(t, docs, 2)
+
+	exporter2, found := getExporterInstanceDocByName(docs, "exporter-2")
+	require.True(t, found)
+	assert.Equal(t, "2026-01-15", exporter2.Metadata.Annotations["jumpstarter.dev/unmanaged"])
+
+	exporter1, found := getExporterInstanceDocByName(docs, "exporter-1")
+	require.True(t, found)
+	assert.Empty(t, exporter1.Metadata.Annotations)
+}
+
+func TestUpdateAnnotationInSourceFile_DecodeErrorIsReturned(t *testing.T) {
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: my-exporter
+spec:
+  type: test
+---
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: broken-exporter
+spec:
+  type: [invalid
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporters.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "my-exporter", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error decoding YAML")
+}
+
+func TestUpdateAnnotationInSourceFile_PreservesLeadingDocStart(t *testing.T) {
+	content := `---
+apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-1
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test
+`
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "exporter.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0644))
+
+	err := UpdateAnnotationInSourceFile(filePath, "exporter-1", "jumpstarter.dev/unmanaged", "2026-02-09")
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(result), "---\n"))
+}

--- a/internal/config_lint/lint.go
+++ b/internal/config_lint/lint.go
@@ -77,6 +77,13 @@ func validateTemplates(cfg *config.Config) map[string][]error {
 	// TODO: Implement template validation logic
 	// This is a placeholder for template validation functionality
 	for _, exporterInstance := range cfg.Loaded.GetExporterInstances() {
+		if exporterInstance == nil {
+			continue
+		}
+		if isUnmanaged, _ := exporterInstance.IsUnmanaged(); isUnmanaged {
+			continue
+		}
+
 		// Template validation logic would go here
 		// For now, this is just a placeholder that doesn't report any errors
 		if exporterInstance.HasConfigTemplate() {
@@ -136,6 +143,13 @@ func validateReferences(cfg *config.Config) map[string][]error {
 
 	// Validate ExporterInstance references
 	for name, instance := range cfg.Loaded.GetExporterInstances() {
+		if instance == nil {
+			continue
+		}
+		if isUnmanaged, _ := instance.IsUnmanaged(); isUnmanaged {
+			continue
+		}
+
 		sourceFile := getSourceFile("ExporterInstance", name)
 
 		// Check DutLocationRef

--- a/internal/config_lint/lint_test.go
+++ b/internal/config_lint/lint_test.go
@@ -214,3 +214,72 @@ func TestLint(t *testing.T) {
 		assert.True(t, hasInvalidExporterError && len(invalidExporterErrors) > 0, "Should have errors for invalid exporter with missing template")
 	})
 }
+
+func TestValidateTemplates_SkipsUnmanagedExporters(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*v1alphaConfig.ExporterInstance{
+				"unmanaged-exporter": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unmanaged-exporter",
+						Annotations: map[string]string{
+							v1alphaConfig.UnmanagedAnnotation: "2026-02-01",
+						},
+					},
+					Spec: v1alphaConfig.ExporterInstanceSpec{
+						ConfigTemplateRef: v1alphaConfig.ConfigTemplateRef{
+							Name: "missing-template",
+						},
+					},
+				},
+			},
+			ExporterConfigTemplates: map[string]*v1alphaConfig.ExporterConfigTemplate{},
+		},
+	}
+
+	errorsByItem := validateTemplates(cfg)
+	assert.Empty(t, errorsByItem)
+}
+
+func TestValidateReferences_SkipsUnmanagedExporters(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*v1alphaConfig.ExporterInstance{
+				"unmanaged-exporter": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unmanaged-exporter",
+						Annotations: map[string]string{
+							v1alphaConfig.UnmanagedAnnotation: "2026-02-01",
+						},
+					},
+					Spec: v1alphaConfig.ExporterInstanceSpec{
+						DutLocationRef: v1alphaConfig.DutLocationRef{
+							Name: "missing-location",
+						},
+						ExporterHostRef: v1alphaConfig.ExporterHostRef{
+							Name: "missing-host",
+						},
+						JumpstarterInstanceRef: v1alphaConfig.JumsptarterInstanceRef{
+							Name: "missing-jumpstarter-instance",
+						},
+						ConfigTemplateRef: v1alphaConfig.ConfigTemplateRef{
+							Name: "missing-template",
+						},
+					},
+				},
+			},
+			PhysicalLocations:       map[string]*v1alphaConfig.PhysicalLocation{},
+			ExporterHosts:           map[string]*v1alphaConfig.ExporterHost{},
+			JumpstarterInstances:    map[string]*v1alphaConfig.JumpstarterInstance{},
+			ExporterConfigTemplates: map[string]*v1alphaConfig.ExporterConfigTemplate{},
+			SourceFiles: map[string]map[string]string{
+				"ExporterInstance": {
+					"unmanaged-exporter": "test-exporter.yaml",
+				},
+			},
+		},
+	}
+
+	errorsByFile := validateReferences(cfg)
+	assert.Empty(t, errorsByFile)
+}

--- a/internal/exporter/host/host.go
+++ b/internal/exporter/host/host.go
@@ -90,10 +90,18 @@ func NewExporterHostSyncer(cfg *config.Config,
 
 // isExporterInstanceDead checks if an exporter instance is marked as dead via annotation
 func isExporterInstanceDead(instance *api.ExporterInstance) (bool, string) {
-	if deadAnnotation, exists := instance.Annotations["dead"]; exists {
-		return true, deadAnnotation
+	return instance.IsDead()
+}
+
+func isExporterInstanceUnmanaged(instance *api.ExporterInstance) (bool, string) {
+	return instance.IsUnmanaged()
+}
+
+func unmanagedReason(annotation string) string {
+	if annotation == "" {
+		return "missing discovery date"
 	}
-	return false, ""
+	return annotation
 }
 
 // filterExporterInstances filters instances, checks if all are dead, and handles skip printing
@@ -114,34 +122,42 @@ func (e *ExporterHostSyncer) filterExporterInstances(hostName string, exporterIn
 		return nil
 	}
 
-	// Check if all remaining instances are dead
-	allDead := true
-	var deadAnnotations []string
+	activeInstances := make([]*api.ExporterInstance, 0, len(exporterInstances))
+	inactiveReasons := make([]string, 0, len(exporterInstances))
 
 	for _, exporterInstance := range exporterInstances {
-		if isDead, deadAnnotation := isExporterInstanceDead(exporterInstance); isDead {
-			deadAnnotations = append(deadAnnotations, fmt.Sprintf("%s: %s", exporterInstance.Name, deadAnnotation))
-		} else {
-			allDead = false
-			break
+		if exporterInstance == nil {
+			continue
 		}
+
+		if isDead, deadAnnotation := isExporterInstanceDead(exporterInstance); isDead {
+			out.Printf("    📟 Exporter instance: %s skipped - dead: %s\n", exporterInstance.Name, deadAnnotation)
+			inactiveReasons = append(inactiveReasons, fmt.Sprintf("%s dead: %s", exporterInstance.Name, deadAnnotation))
+			continue
+		}
+
+		if isUnmanaged, unmanagedAnnotation := isExporterInstanceUnmanaged(exporterInstance); isUnmanaged {
+			reason := unmanagedReason(unmanagedAnnotation)
+			out.Printf("    📟 Exporter instance: %s skipped - unmanaged: %s\n", exporterInstance.Name, reason)
+			inactiveReasons = append(inactiveReasons, fmt.Sprintf("%s unmanaged: %s", exporterInstance.Name, reason))
+			continue
+		}
+
+		activeInstances = append(activeInstances, exporterInstance)
 	}
 
-	// all instances are dead
-	if allDead {
-		out.Printf("\n💻  Exporter host: %s skipped - all instances dead: [%s]\n", hostName, strings.Join(deadAnnotations, ", "))
+	// all instances are dead/unmanaged
+	if len(activeInstances) == 0 && len(inactiveReasons) > 0 {
+		out.Printf("\n💻  Exporter host: %s skipped - all instances inactive: [%s]\n", hostName, strings.Join(inactiveReasons, ", "))
 		return nil
 	}
 
-	return exporterInstances
+	return activeInstances
 }
 
 // processExporterInstance processes a single exporter instance
 func (e *ExporterHostSyncer) processExporterInstance(exporterInstance *api.ExporterInstance, hostSsh ssh.HostManager, out *OutputBuffer) error {
-	if isDead, deadAnnotation := isExporterInstanceDead(exporterInstance); isDead {
-		out.Printf("    📟 Exporter instance: %s skipped - dead: %s\n", exporterInstance.Name, deadAnnotation)
-		return nil
-	}
+	// filterExporterInstances only passes active (non-dead, managed) instances here.
 
 	out.Printf("    📟 Exporter instance: %s\n", exporterInstance.Name)
 	errName := "ExporterInstance:" + exporterInstance.Name

--- a/internal/exporter/host/host_test.go
+++ b/internal/exporter/host/host_test.go
@@ -47,7 +47,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "instance2",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -62,7 +62,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "instance1",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -70,7 +70,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "instance2",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -85,7 +85,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "instance1",
 						Annotations: map[string]string{
-							"dead": "false",
+							v1alpha1.DeadAnnotation: "false",
 						},
 					},
 				},
@@ -100,7 +100,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "instance1",
 						Annotations: map[string]string{
-							"dead": "maybe",
+							v1alpha1.DeadAnnotation: "maybe",
 						},
 					},
 				},
@@ -117,7 +117,7 @@ func TestDeadAnnotationFiltering(t *testing.T) {
 			deadCount := 0
 
 			for _, exporterInstance := range tt.exporterInstances {
-				if _, exists := exporterInstance.Annotations["dead"]; exists {
+				if isDead, _ := exporterInstance.IsDead(); isDead {
 					deadCount++
 				} else {
 					aliveInstances = append(aliveInstances, exporterInstance)
@@ -150,7 +150,7 @@ func TestHostSkippingBehavior(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dead-instance",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -166,7 +166,7 @@ func TestHostSkippingBehavior(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dead-instance-1",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -174,7 +174,7 @@ func TestHostSkippingBehavior(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "dead-instance-2",
 						Annotations: map[string]string{
-							"dead": "true",
+							v1alpha1.DeadAnnotation: "true",
 						},
 					},
 				},
@@ -211,7 +211,7 @@ func TestHostSkippingBehavior(t *testing.T) {
 			aliveCount := 0
 
 			for _, exporterInstance := range tt.exporterInstances {
-				if _, exists := exporterInstance.Annotations["dead"]; !exists {
+				if isDead, _ := exporterInstance.IsDead(); !isDead {
 					allDead = false
 					aliveCount++
 				}
@@ -371,4 +371,108 @@ func TestFormatDuration(t *testing.T) {
 			assert.Equal(t, tt.expected, formatDuration(tt.duration))
 		})
 	}
+}
+
+func TestIsExporterInstanceUnmanaged(t *testing.T) {
+	tests := []struct {
+		name          string
+		instance      *v1alpha1.ExporterInstance
+		expectedState bool
+		expectedValue string
+	}{
+		{
+			name: "managed exporter",
+			instance: &v1alpha1.ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "managed"},
+			},
+			expectedState: false,
+			expectedValue: "",
+		},
+		{
+			name: "unmanaged exporter with empty value",
+			instance: &v1alpha1.ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unmanaged-empty",
+					Annotations: map[string]string{
+						v1alpha1.UnmanagedAnnotation: "",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "",
+		},
+		{
+			name: "unmanaged exporter with discovery date",
+			instance: &v1alpha1.ExporterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unmanaged-dated",
+					Annotations: map[string]string{
+						v1alpha1.UnmanagedAnnotation: "2026-02-01",
+					},
+				},
+			},
+			expectedState: true,
+			expectedValue: "2026-02-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isUnmanaged, value := isExporterInstanceUnmanaged(tt.instance)
+			assert.Equal(t, tt.expectedState, isUnmanaged)
+			assert.Equal(t, tt.expectedValue, value)
+		})
+	}
+}
+
+func TestFilterExporterInstances_SkipsUnmanaged(t *testing.T) {
+	syncer := &ExporterHostSyncer{}
+
+	t.Run("mixed managed and unmanaged", func(t *testing.T) {
+		instances := []*v1alpha1.ExporterInstance{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "managed",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unmanaged",
+					Annotations: map[string]string{
+						v1alpha1.UnmanagedAnnotation: "2026-02-10",
+					},
+				},
+			},
+		}
+
+		out := NewOutputBuffer("host-1", len(instances))
+		filtered := syncer.filterExporterInstances("host-1", instances, out)
+		assert.Len(t, filtered, 1)
+		assert.Equal(t, "managed", filtered[0].Name)
+	})
+
+	t.Run("all unmanaged", func(t *testing.T) {
+		instances := []*v1alpha1.ExporterInstance{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unmanaged-1",
+					Annotations: map[string]string{
+						v1alpha1.UnmanagedAnnotation: "2026-02-10",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unmanaged-2",
+					Annotations: map[string]string{
+						v1alpha1.UnmanagedAnnotation: "",
+					},
+				},
+			},
+		}
+
+		out := NewOutputBuffer("host-1", len(instances))
+		filtered := syncer.filterExporterInstances("host-1", instances, out)
+		assert.Nil(t, filtered)
+	})
 }

--- a/internal/instance/exporter_sync.go
+++ b/internal/instance/exporter_sync.go
@@ -255,7 +255,7 @@ func (i *Instance) getGrpcEndpoint(exporterName string, cfg *config.Config) (str
 	return "", fmt.Errorf("exporter instance %s not found in config", exporterName)
 }
 
-func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter *regexp.Regexp) (map[string]template.ServiceParameters, error) {
+func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter *regexp.Regexp, unmanagedExporters map[string]bool) (map[string]template.ServiceParameters, error) {
 	serviceParametersMap := make(map[string]template.ServiceParameters)
 	fmt.Printf("\n🔄 [%s] Syncing exporters ===========================\n\n", i.config.Name)
 	instanceExporters, err := i.listExporters(ctx)
@@ -263,45 +263,35 @@ func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter
 		return nil, fmt.Errorf("[%s] failed to list exporters: %w", i.config.Name, err)
 	}
 
-	// convert configExporterMap to a map of exporter name to exporter objects
-	configExporterMap := make(map[string]v1alpha1.Exporter)
-	for _, cfgExporterInstance := range cfg.Loaded.ExporterInstances {
-		exporterObj, err := GetExporterObjectForInstance(cfg, cfgExporterInstance, i.config.Name)
-		if err != nil {
-			return nil, fmt.Errorf("[%s] failed to get exporter object for instance %s: %w", i.config.Name, cfgExporterInstance.Name, err)
-		}
-		if exporterObj != nil {
-			configExporterMap[cfgExporterInstance.Name] = *exporterObj
-		}
+	configExporterMap, err := buildConfigExporterMap(cfg, i.config.Name, unmanagedExporters)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] failed to build exporter config map: %w", i.config.Name, err)
 	}
 
-	// Apply filter if provided
-	if filter != nil {
-		filteredInstanceItems := []v1alpha1.Exporter{}
-		for _, item := range instanceExporters.Items {
-			if filter.MatchString(item.Name) {
-				filteredInstanceItems = append(filteredInstanceItems, item)
-			}
-		}
-		instanceExporters.Items = filteredInstanceItems
-
-		filteredConfigExporterMap := make(map[string]v1alpha1.Exporter)
-		for name, exporterObj := range configExporterMap {
-			if filter.MatchString(name) {
-				filteredConfigExporterMap[name] = exporterObj
-			}
-		}
-		configExporterMap = filteredConfigExporterMap
-	}
+	instanceExporterItems := instanceExporters.Items
+	configExporterMap, instanceExporterItems = applyExporterFilter(filter, instanceExporterItems, configExporterMap)
 
 	// create a exporterMap from exporters in the cluster
 	instanceExporterMap := make(map[string]v1alpha1.Exporter)
-	for _, instExporter := range instanceExporters.Items {
+	for _, instExporter := range instanceExporterItems {
 		instanceExporterMap[instExporter.Name] = instExporter
 	}
 
+	loggedUnmanagedSkips := make(map[string]bool)
+	logUnmanagedSkip := func(name string) {
+		if loggedUnmanagedSkips[name] {
+			return
+		}
+		fmt.Printf("⏸️  [%s] Skipping unmanaged exporter %s for sync\n", i.config.Name, name)
+		loggedUnmanagedSkips[name] = true
+	}
+
 	// delete exporters that are not in config
-	for _, instanceExporter := range instanceExporters.Items {
+	for _, instanceExporter := range instanceExporterItems {
+		if isUnmanagedExporter(instanceExporter.Name, unmanagedExporters) {
+			logUnmanagedSkip(instanceExporter.Name)
+			continue
+		}
 		if _, ok := configExporterMap[instanceExporter.Name]; !ok {
 			err := i.deleteExporter(ctx, instanceExporter.Name)
 			if err != nil {
@@ -348,7 +338,12 @@ func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter
 	}
 
 	// update exporters that are in both config and instance
-	for _, instanceExporter := range instanceExporters.Items {
+	for _, instanceExporter := range instanceExporterItems {
+		if isUnmanagedExporter(instanceExporter.Name, unmanagedExporters) {
+			logUnmanagedSkip(instanceExporter.Name)
+			continue
+		}
+
 		if exporterObj, ok := configExporterMap[instanceExporter.Name]; ok {
 
 			err := i.updateExporter(ctx, &instanceExporter, &exporterObj)
@@ -373,6 +368,57 @@ func (i *Instance) SyncExporters(ctx context.Context, cfg *config.Config, filter
 	}
 
 	return serviceParametersMap, nil
+}
+
+func buildConfigExporterMap(cfg *config.Config, jumpstarterInstance string, unmanagedExporters map[string]bool) (map[string]v1alpha1.Exporter, error) {
+	configExporterMap := make(map[string]v1alpha1.Exporter)
+	for _, cfgExporterInstance := range cfg.Loaded.ExporterInstances {
+		if cfgExporterInstance == nil {
+			continue
+		}
+		if isUnmanagedExporter(cfgExporterInstance.Name, unmanagedExporters) {
+			continue
+		}
+
+		exporterObj, err := GetExporterObjectForInstance(cfg, cfgExporterInstance, jumpstarterInstance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get exporter object for instance %s: %w", cfgExporterInstance.Name, err)
+		}
+		if exporterObj != nil {
+			configExporterMap[cfgExporterInstance.Name] = *exporterObj
+		}
+	}
+	return configExporterMap, nil
+}
+
+func applyExporterFilter(
+	filter *regexp.Regexp,
+	instanceExporterItems []v1alpha1.Exporter,
+	configExporterMap map[string]v1alpha1.Exporter,
+) (map[string]v1alpha1.Exporter, []v1alpha1.Exporter) {
+	if filter == nil {
+		return configExporterMap, instanceExporterItems
+	}
+
+	filteredInstanceItems := make([]v1alpha1.Exporter, 0, len(instanceExporterItems))
+	for _, item := range instanceExporterItems {
+		if filter.MatchString(item.Name) {
+			filteredInstanceItems = append(filteredInstanceItems, item)
+		}
+	}
+
+	filteredConfigExporterMap := make(map[string]v1alpha1.Exporter)
+	for name, exporterObj := range configExporterMap {
+		if filter.MatchString(name) {
+			filteredConfigExporterMap[name] = exporterObj
+		}
+	}
+
+	return filteredConfigExporterMap, filteredInstanceItems
+}
+
+func isUnmanagedExporter(name string, unmanagedExporters map[string]bool) bool {
+	return unmanagedExporters[name]
 }
 
 func GetExporterObjectForInstance(cfg *config.Config, e *v1alpha1Config.ExporterInstance, jumpstarterInstance string) (*v1alpha1.Exporter, error) {

--- a/internal/unmanaged/unmanaged.go
+++ b/internal/unmanaged/unmanaged.go
@@ -1,0 +1,120 @@
+package unmanaged
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	api "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/config"
+)
+
+type Summary struct {
+	Exporters  map[string]bool
+	OldestDays int
+}
+
+func (s Summary) Count() int {
+	return len(s.Exporters)
+}
+
+// ProcessUnmanagedExporters iterates over ExporterInstances and processes the
+// unmanaged annotation. For each unmanaged exporter:
+//   - If the annotation value is empty, sets today's date and writes it back to the source file.
+//   - If the annotation value is a date, calculates days since and prints a warning.
+//   - If the annotation value is invalid, warns but still treats as unmanaged.
+//
+// Returns a summary with unmanaged exporter names and oldest age.
+// nowFunc is injected to make time-based behavior deterministic in tests.
+func ProcessUnmanagedExporters(cfg *config.Config, dryRun bool, nowFunc func() time.Time) Summary {
+	summary := Summary{
+		Exporters: make(map[string]bool),
+	}
+	if nowFunc == nil {
+		nowFunc = time.Now
+	}
+
+	if cfg == nil || cfg.Loaded == nil {
+		return summary
+	}
+
+	for _, exporterInstance := range cfg.Loaded.ExporterInstances {
+		if exporterInstance == nil {
+			continue
+		}
+
+		isUnmanaged, value := exporterInstance.IsUnmanaged()
+		if !isUnmanaged {
+			continue
+		}
+
+		summary.Exporters[exporterInstance.Name] = true
+		daysUnmanaged := 0
+
+		if value == "" {
+			// First discovery - set today's date
+			today := nowFunc().Format("2006-01-02")
+			_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: exporter %s is unmanaged and missing discovery date\n", exporterInstance.Name)
+
+			if dryRun {
+				_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: dry run - would set %s=%s for exporter %s\n",
+					api.UnmanagedAnnotation, today, exporterInstance.Name)
+			} else {
+				// Write back to source file
+				sourceFile := getSourceFile(cfg, exporterInstance.Name)
+				if sourceFile != "" {
+					if err := config.UpdateAnnotationInSourceFile(sourceFile, exporterInstance.Name, api.UnmanagedAnnotation, today); err != nil {
+						_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: failed to write discovery date to %s: %v\n", sourceFile, err)
+					} else {
+						// Keep in-memory state consistent with source file.
+						if exporterInstance.Annotations == nil {
+							exporterInstance.Annotations = make(map[string]string)
+						}
+						exporterInstance.Annotations[api.UnmanagedAnnotation] = today
+					}
+				} else {
+					_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: source file not found for unmanaged exporter %s\n", exporterInstance.Name)
+				}
+			}
+		} else {
+			// Parse the date and calculate days since
+			discoveryDate, err := time.Parse("2006-01-02", value)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: exporter %s is unmanaged (invalid date: %s)\n", exporterInstance.Name, value)
+			} else {
+				now := nowFunc()
+				if discoveryDate.After(now) {
+					_, _ = fmt.Fprintf(
+						os.Stderr,
+						"⚠️  Warning: exporter %s has unmanaged discovery date in the future: %s\n",
+						exporterInstance.Name,
+						value,
+					)
+					daysUnmanaged = 0
+				} else {
+					daysUnmanaged = int(math.Floor(now.Sub(discoveryDate).Hours() / 24))
+					_, _ = fmt.Fprintf(os.Stderr, "⚠️  Warning: exporter %s has been unmanaged for %d days\n", exporterInstance.Name, daysUnmanaged)
+				}
+			}
+		}
+
+		if daysUnmanaged > summary.OldestDays {
+			summary.OldestDays = daysUnmanaged
+		}
+	}
+
+	return summary
+}
+
+// getSourceFile looks up the source file for an ExporterInstance
+func getSourceFile(cfg *config.Config, name string) string {
+	if cfg.Loaded.SourceFiles == nil {
+		return ""
+	}
+	exporterSources, ok := cfg.Loaded.SourceFiles["ExporterInstance"]
+	if !ok {
+		return ""
+	}
+	return exporterSources[name]
+}

--- a/internal/unmanaged/unmanaged_test.go
+++ b/internal/unmanaged/unmanaged_test.go
@@ -1,0 +1,278 @@
+package unmanaged
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	api "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func fixedNow() time.Time {
+	return time.Date(2026, time.February, 17, 12, 0, 0, 0, time.UTC)
+}
+
+func TestProcessUnmanagedExporters_NoUnmanaged(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.Empty(t, result.Exporters)
+}
+
+func TestProcessUnmanagedExporters_WithDate(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "2026-01-01",
+						},
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+	assert.Len(t, result.Exporters, 1)
+}
+
+func TestProcessUnmanagedExporters_EmptyValueSetsDate(t *testing.T) {
+	// Create a temp YAML file for write-back
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "exporter.yaml")
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-1
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test
+`
+	require.NoError(t, os.WriteFile(yamlFile, []byte(content), 0644))
+
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "",
+						},
+					},
+				},
+			},
+			SourceFiles: map[string]map[string]string{
+				"ExporterInstance": {
+					"exporter-1": yamlFile,
+				},
+			},
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+
+	// Verify in-memory annotation was updated
+	today := fixedNow().Format("2006-01-02")
+	assert.Equal(t, today, cfg.Loaded.ExporterInstances["exporter-1"].Annotations[api.UnmanagedAnnotation])
+
+	// Verify file was updated
+	fileContent, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(fileContent), today)
+}
+
+func TestProcessUnmanagedExporters_EmptyValueWriteFailureDoesNotUpdateInMemory(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingFile := filepath.Join(tmpDir, "missing-exporter.yaml")
+
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "",
+						},
+					},
+				},
+			},
+			SourceFiles: map[string]map[string]string{
+				"ExporterInstance": {
+					"exporter-1": missingFile,
+				},
+			},
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+	assert.Equal(t, "", cfg.Loaded.ExporterInstances["exporter-1"].Annotations[api.UnmanagedAnnotation])
+}
+
+func TestProcessUnmanagedExporters_InvalidDate(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "not-a-date",
+						},
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	// Should still be treated as unmanaged
+	assert.True(t, result.Exporters["exporter-1"])
+}
+
+func TestProcessUnmanagedExporters_FutureDate(t *testing.T) {
+	futureDate := fixedNow().AddDate(0, 0, 7).Format("2006-01-02")
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: futureDate,
+						},
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+	assert.Equal(t, 0, result.OldestDays)
+}
+
+func TestProcessUnmanagedExporters_MixedExporters(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"managed-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managed-1",
+					},
+				},
+				"unmanaged-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unmanaged-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "2026-02-01",
+						},
+					},
+				},
+				"managed-2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managed-2",
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.Len(t, result.Exporters, 1)
+	assert.True(t, result.Exporters["unmanaged-1"])
+	assert.NotContains(t, result.Exporters, "managed-1")
+	assert.NotContains(t, result.Exporters, "managed-2")
+}
+
+func TestProcessUnmanagedExporters_DeadAndUnmanaged(t *testing.T) {
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.DeadAnnotation:      "broken hardware",
+							api.UnmanagedAnnotation: "2026-01-15",
+						},
+					},
+				},
+			},
+			SourceFiles: make(map[string]map[string]string),
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, false, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+}
+
+func TestProcessUnmanagedExporters_EmptyValueDryRunDoesNotWriteFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "exporter.yaml")
+	content := `apiVersion: jumpstarter.dev/v1alpha1
+kind: ExporterInstance
+metadata:
+  name: exporter-1
+  annotations:
+    jumpstarter.dev/unmanaged: ""
+spec:
+  type: test
+`
+	require.NoError(t, os.WriteFile(yamlFile, []byte(content), 0644))
+
+	cfg := &config.Config{
+		Loaded: &config.LoadedLabConfig{
+			ExporterInstances: map[string]*api.ExporterInstance{
+				"exporter-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exporter-1",
+						Annotations: map[string]string{
+							api.UnmanagedAnnotation: "",
+						},
+					},
+				},
+			},
+			SourceFiles: map[string]map[string]string{
+				"ExporterInstance": {
+					"exporter-1": yamlFile,
+				},
+			},
+		},
+	}
+
+	result := ProcessUnmanagedExporters(cfg, true, fixedNow)
+	assert.True(t, result.Exporters["exporter-1"])
+
+	fileContent, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(fileContent), `jumpstarter.dev/unmanaged: ""`)
+}


### PR DESCRIPTION
This patch introduces the ability to skip sync for exporters marked with the unmanaged annotations. This is useful when working on exporters (driver development, maintenance, etc).

It also produces a warning when applying so the admin is aware of unmanaged exporters to avoid leaving them out of sync for too long

fixes https://github.com/jumpstarter-dev/jumpstarter-lab-config/issues/25