### PR TITLE
Remove replace directive, import from jumpstarter/controller directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/google/go-cmp v0.7.0
-	github.com/jumpstarter-dev/jumpstarter-controller v0.5.1-0.20250606161717-bc276583f2c6
+	github.com/jumpstarter-dev/jumpstarter/controller v0.0.0-20260626134506-78777b5a62fe
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/pkg/sftp v1.13.9
 	github.com/spf13/cobra v1.8.1
@@ -95,5 +95,3 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// jumpstarter-controller repo is deprecated; source moved to jumpstarter monorepo (v0.9.0-rc.1)
-replace github.com/jumpstarter-dev/jumpstarter-controller => github.com/jumpstarter-dev/jumpstarter/controller v0.0.0-20260626134506-78777b5a62fe

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	jsApi "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	jsApi "github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	api "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/container"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/vars"

--- a/internal/instance/client_sync.go
+++ b/internal/instance/client_sync.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/instance/exporter_sync.go
+++ b/internal/instance/exporter_sync.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	v1alpha1Config "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/config"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/exporter/template"

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	v1alphaConfig "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/instance/instance_test.go
+++ b/internal/instance/instance_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
+	"github.com/jumpstarter-dev/jumpstarter/controller/api/v1alpha1"
 	v1alphaConfig "github.com/jumpstarter-dev/jumpstarter-lab-config/api/v1alpha1"
 	"github.com/jumpstarter-dev/jumpstarter-lab-config/internal/config"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
## Summary

Remove the `replace` directive and update all imports to use the canonical monorepo module path directly:

```
github.com/jumpstarter-dev/jumpstarter-controller
→ github.com/jumpstarter-dev/jumpstarter/controller
```

## Changes

- **`go.mod`** — switched require from `jumpstarter-controller` to `jumpstarter/controller`, removed `replace` directive
- **5 Go files** — updated import paths

## Dependencies

This PR depends on https://github.com/jumpstarter-dev/jumpstarter/pull/875 being merged first, which updates the upstream module declaration to match the monorepo path. Until that lands, `go mod tidy` will fail because the module still declares itself as `jumpstarter-controller`.

## Merge order

1. Merge jumpstarter-dev/jumpstarter#875
2. Update the version hash in `go.mod` here to point to the merged commit
3. Run `go mod tidy` to update `go.sum`
4. Merge this PR